### PR TITLE
refactor variable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**4.0.0+1.9.1**
+
+- introduce variables `cilium_release_name` and `cilium_repo_name`
+- `cilium_chart_name` had the wrong value. The `cilium_chart_name` was actually the `cilium_release_name`. If you used the default `cilium_chart_name: "cilium"` nothing will change for you. Otherwise you may need `cilium_release_name`, `cilium_repo_name` and `cilium_chart_name` accordingly.
+
 **3.0.0+1.9.1**
 
 - upgrade to Cilium v1.9.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,15 @@
 ---
-# Helm chart version
+# Helm chart version (uses Cilium v1.9.1)
 cilium_chart_version: "1.9.1"
 
+# Helm release name
+cilium_release_name: "cilium"
+
+# Helm repository name
+cilium_repo_name: "cilium"
+
 # Helm chart name
-cilium_chart_name: "cilium"
+cilium_chart_name: "{{ cilium_repo_name }}/{{ cilium_release_name }}"
 
 # Helm chart URL
 cilium_chart_url: "https://helm.cilium.io/"

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -5,7 +5,7 @@
     set -o pipefail
     set -o nounset
 
-    helm uninstall {{ cilium_chart_name }} --namespace {{ cilium_namespace }}
+    helm uninstall {{ cilium_release_name }} --namespace {{ cilium_namespace }}
 
     exit 0
   run_once: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   run_once: True
 
 - name: Register if Cilium Helm repository is installed
-  command: helm search repo {{ cilium_chart_name }} -n {{ cilium_namespace }}
+  command: helm search repo {{ cilium_chart_name }} -n {{ cilium_namespace }} --version ^{{ cilium_chart_version }}
   register: cilium_repo_installed
   changed_when: False
   delegate_to: 127.0.0.1
@@ -80,8 +80,9 @@
         set -o pipefail
         set -o nounset
 
-        helm install {{ cilium_chart_name }} cilium/cilium --version {{ cilium_chart_version }}
+        helm install {{ cilium_release_name }} {{ cilium_chart_name }}
         --namespace {{ cilium_namespace }}
+        --version {{ cilium_chart_version }}
         --values {{ cilium_values_tmp_file.path }}
 
         exit 0

--- a/tasks/pre_flight_check.yml
+++ b/tasks/pre_flight_check.yml
@@ -6,6 +6,11 @@
       run_once: True
       delegate_to: 127.0.0.1
 
+    - name: Waiting for pre flight deployment
+      wait_for:
+        timeout: 10
+      run_once: True
+
     - name: Fetch current Cilium pre flight DaemonSet state
       k8s_info:
         api_version: v1

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -29,8 +29,9 @@
         set -o pipefail
         set -o nounset
 
-        helm template {{ cilium_chart_name }} cilium/cilium --version {{ cilium_chart_version }}
+        helm template {{ cilium_release_name }} {{ cilium_chart_name }}
         --namespace {{ cilium_namespace }}
+        --version {{ cilium_chart_version }}
         --values {{ cilium_values_tmp_file.path }}
 
         exit 0

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -26,7 +26,7 @@
   k8s_info:
     api_version: v1
     kind: DaemonSet
-    name: "{{ cilium_chart_name }}"
+    name: "{{ cilium_release_name }}"
     namespace: "{{ cilium_namespace }}"
   register: cilium_daemonset
   run_once: True
@@ -88,7 +88,7 @@
     set -o pipefail
     set -o nounset
 
-    helm install cilium-preflight cilium/cilium --version {{ cilium_chart_version }}
+    helm install cilium-preflight {{ cilium_chart_name }} --version {{ cilium_chart_version }}
       --namespace {{ cilium_namespace }}
       --set preflight.enabled=true
       --set agent=false
@@ -182,8 +182,9 @@
         set -o pipefail
         set -o nounset
 
-        helm upgrade {{ cilium_chart_name }} cilium/cilium --version {{ cilium_chart_version }}
+        helm upgrade {{ cilium_release_name }} {{ cilium_chart_name }}
         --namespace {{ cilium_namespace }}
+        --version {{ cilium_chart_version }}
         --values {{ cilium_values_tmp_file.path }}
 
         exit 0

--- a/templates/cilium_values_default.yml.j2
+++ b/templates/cilium_values_default.yml.j2
@@ -11,9 +11,14 @@ keepDeprecatedProbes: true
 
 # To minimize datapath disruption during the upgrade, the upgradeCompatibility
 # option should be set to the INITIAL Cilium version which was installed in this
-# cluster. Valid options are:
+# cluster.
+#
+# This is flag is not required for new installations!
+#
+# Valid options are:
 # 1.7 -> if the initial install was Cilium 1.7.x or earlier.
 # 1.8 -> if the initial install was Cilium 1.8.x.
+# 1.8 -> if the initial install was Cilium 1.9.x.
 upgradeCompatibility: "1.7"
 
 cni:


### PR DESCRIPTION
- introduce variables `cilium_release_name` and `cilium_repo_name`
- `cilium_chart_name` had the wrong value. The `cilium_chart_name` was actually the `cilium_release_name`. If you used the default `cilium_chart_name: "cilium"` nothing will change for you. Otherwise you may need `cilium_release_name`, `cilium_repo_name` and `cilium_chart_name` accordingly.