### PR TITLE
update Cilium to v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**5.1.0+1.10.4**
+
+- upgrade to Cilium v1.10.4
+- add `bpf.masquerade: true` option to enable native IP masquerade support in eBPF. The eBPF-based masquerading implementation is the most efficient implementation. It requires Linux kernel >= 4.19. See: [Cilium Masquerading](https://docs.cilium.io/en/stable/concepts/networking/masquerading/)
+
 **5.0.0+1.10.1**
 
 - upgrade to Cilium v1.10.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs [Cilium](https://docs.cilium.io) network on a Kuberne
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `5.0.0+1.10.1` means this is release `5.0.0` of this role and it contains Cilium chart version `1.10.1`. If the role itself changes `X.Y.Z` before `+` will increase. If the Cilium chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Cilium release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `5.1.0+1.10.4` means this is release `5.1.0` of this role and it contains Cilium chart version `1.10.4`. If the role itself changes `X.Y.Z` before `+` will increase. If the Cilium chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Cilium release.
 
 Requirements
 ------------
@@ -20,7 +20,7 @@ Role Variables
 
 ```
 # Helm chart version
-cilium_chart_version: "1.10.1"
+cilium_chart_version: "1.10.4"
 
 # Helm chart name
 cilium_chart_name: "cilium"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Helm chart version (uses Cilium v1.10.1)
-cilium_chart_version: "1.10.1"
+# Helm chart version (uses Cilium v1.10.4)
+cilium_chart_version: "1.10.4"
 
 # Helm release name
 cilium_release_name: "cilium"

--- a/templates/cilium_values_default.yml.j2
+++ b/templates/cilium_values_default.yml.j2
@@ -21,6 +21,12 @@ keepDeprecatedProbes: true
 # 1.8 -> if the initial install was Cilium 1.9.x.
 upgradeCompatibility: "1.7"
 
+# The eBPF-based masquerading implementation is the most efficient implementation.
+# It requires Linux kernel >= 4.19.
+# See: https://docs.cilium.io/en/stable/concepts/networking/masquerading/
+bpf:
+  masquerade: true
+
 cni:
   chainingMode: portmap
 {% if cilium_etcd_enabled is defined and cilium_etcd_enabled == "true" -%}


### PR DESCRIPTION
- upgrade to Cilium v1.10.4
- add `bpf.masquerade: true` option to enable native IP masquerade support in eBPF. The eBPF-based masquerading implementation is the most efficient implementation. It requires Linux kernel >= 4.19. See: [Cilium Masquerading](https://docs.cilium.io/en/stable/concepts/networking/masquerading/)