### PR TITLE
Improvements to the playbook.

### DIFF
--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -36,9 +36,9 @@
         state: absent
       notify:
         - reload systemd
-  when: |
-    ansible_lsb.release is defined and
-    ansible_lsb.release is version('20.04', '<')
+  when:
+    - ansible_lsb.release is defined
+    - ansible_lsb.release is version('20.04', '<')
 
 - name: Delete namespace used by Cilium
   k8s:

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -36,8 +36,9 @@
         state: absent
       notify:
         - reload systemd
-  when:
-    - ansible_lsb.release is version('20.04', '<')
+  when: |
+    ansible_lsb.release is defined and
+    ansible_lsb.release is version('20.04', '<')
 
 - name: Delete namespace used by Cilium
   k8s:

--- a/tasks/helm_repository.yml
+++ b/tasks/helm_repository.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Register if Cilium Helm repository is installed
   command: helm search repo {{ cilium_repo_name }} -n {{ cilium_namespace }} --version ^{{ cilium_chart_version }} 2>/dev/null
   register: cilium_repo_installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,7 +40,9 @@
         enabled: true
         state: started
   when:
-    - ansible_lsb.release is version('20.04', '<')
+    - |
+      ansible_lsb.release is defined and 
+      ansible_lsb.release is version('20.04', '<')
 
 - name: Install Cilium etcd secrets in k8s
   k8s:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,19 +8,7 @@
   delegate_to: 127.0.0.1
   run_once: true
 
-- name: Register if Cilium Helm repository is installed
-  command: helm search repo {{ cilium_chart_name }} -n {{ cilium_namespace }} --version ^{{ cilium_chart_version }}
-  register: cilium_repo_installed
-  changed_when: false
-  delegate_to: 127.0.0.1
-  run_once: true
-
-- name: Add cilium helm repository
-  command: helm repo add {{ cilium_chart_name }} {{ cilium_chart_url }}
-  changed_when: false
-  delegate_to: 127.0.0.1
-  run_once: true
-  when: "cilium_repo_installed.stdout.find(cilium_chart_name) == -1"
+- include_tasks: repo.yml
 
 - name: BPFFS handling for Ubuntu 18.04
   block:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
   delegate_to: 127.0.0.1
   run_once: true
 
-- include_tasks: repo.yml
+- include_tasks: helm_repository.yml
 
 - name: BPFFS handling for Ubuntu 18.04
   block:
@@ -28,9 +28,8 @@
         enabled: true
         state: started
   when:
-    - |
-      ansible_lsb.release is defined and 
-      ansible_lsb.release is version('20.04', '<')
+    - ansible_lsb.release is defined 
+    - ansible_lsb.release is version('20.04', '<')
 
 - name: Install Cilium etcd secrets in k8s
   k8s:

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Register if Cilium Helm repository is installed
+  command: helm search repo {{ cilium_repo_name }} -n {{ cilium_namespace }} --version ^{{ cilium_chart_version }} 2>/dev/null
+  register: cilium_repo_installed
+  changed_when: false
+  delegate_to: 127.0.0.1
+  run_once: true
+  ignore_errors: true
+
+- name: Add cilium helm repository
+  command: helm repo add {{ cilium_repo_name }} {{ cilium_chart_url }}
+  changed_when: false
+  delegate_to: 127.0.0.1
+  run_once: true
+  when: |
+    cilium_repo_installed.failed or
+    cilium_repo_installed.stdout.find(cilium_repo_name) == -1

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -1,4 +1,7 @@
 ---
+
+- include_tasks: repo.yml
+
 - name: Render values
   block:
     - name: Create temporary file for Helm values

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -1,5 +1,4 @@
 ---
-
 - include_tasks: repo.yml
 
 - name: Render values


### PR DESCRIPTION
This changes the following:

[Skip BPFFS installation when LSB is not available](https://github.com/githubixx/ansible-role-cilium-kubernetes/commit/748237bf75422b7cedb547961a1ea7b38f6ec2c7)
CentOS does not come with LSB by default. This skips installation of BPFFS when the `ansible_lsb`
fact is not available.

This might not be 100% correct, but it's better than having support only for Ubuntu.

[Install Cilium repository when rendering the template](https://github.com/githubixx/ansible-role-cilium-kubernetes/commit/4f078da30a49bcde415c0c22e14f75231919fe56)
When attempting to render the helm chart template in a clean helm installation, the playbook fails
because the repository has not yet been installed. This makes sure the repository exists before
attempting to render the template.

Additionally, when there are no repositories installed in helm, the `helm repo list` command exists
with an error. In such cases, the playbook would also fail. Now, errors are ignored when listing the
available repositories and the install command is ran wether the repo command failed or the
repository is not yet available. When the `helm repo list` command throws an error not related to
the absence of repositories, the install command will most likely throw it too, so the play will
fail in such cases.

