### PR TITLE
8.0.0+1.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+**8.0.0+1.12.3**
+
+- upgrade to Cilium v1.12.3
+- introduce `cilium_delegate_to` variable. Previously this was hard coded to `127.0.0.1` and it's also the default of this variable.
+- introduce `cilium_helm_show_commands` variable (see README for more information)
+- introduce `cilium_template_output_directory` variable (see README for more information)
+- introduce `Molecule` tests
+- don't use `shell` module anymore to execute `helm` command. Now `kubernetes.core.helm*` modules are used.
+- use two underscores for internal variables
+- ansible-lint: fix various issues like using FQDN Ansible module names now
+- add `requirements.yml`
+- add `collections.yml`
+
 **7.1.1+1.12.1**
 
 - fix YAML syntax in `tasks/main.yml`

--- a/collections.yml
+++ b/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - kubernetes.core

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Helm chart version (uses Cilium v1.12.1)
-cilium_chart_version: "1.12.1"
+# Helm chart version (uses Cilium v1.12.3)
+cilium_chart_version: "1.12.3"
 
 # Helm release name
 cilium_release_name: "cilium"
@@ -17,7 +17,6 @@ cilium_chart_url: "https://helm.cilium.io/"
 # Kubernetes namespace where Cilium resources should be installed
 cilium_namespace: "cilium"
 
-#
 # etcd settings. If "cilium_etcd_enabled" variable is defined and set to "true",
 # Cilium etcd settings are generated and deployed. Otherwise all the following
 # "cilium_etcd_*" settings are ignored.
@@ -72,3 +71,19 @@ cilium_etcd_certfile: "cert-cilium.pem"
 
 # etcd certificate key file (file will be fetched in "cilium_etcd_cert_directory")
 cilium_etcd_keyfile: "cert-cilium-key.pem"
+
+# By default all tasks that needs to communicate with the Kubernetes
+# cluster are executed on your local host (127.0.0.1). But if that one
+# doesn't have direct connection to this cluster or should be executed
+# elsewhere this variable can be changed accordingly.
+cilium_delegate_to: 127.0.0.1
+
+# Shows the "helm" command that was executed if a task uses Helm to
+# install, update/upgrade or deletes such a resource.
+cilium_helm_show_commands: false
+
+# Without "action" variable defined this role will only render a file
+# with all the resources that will be installed or upgraded. The rendered
+# file with the resources will be called "template.yml" and will be
+# placed in the directory specified below.
+cilium_template_output_directory: "{{ '~/cilium/template' | expanduser }}"

--- a/molecule/kvm/collections.yml
+++ b/molecule/kvm/collections.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+collections:
+  - kubernetes.core
+  - community.docker

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: all
+  tasks:
+    - name: Include Cilium role
+      ansible.builtin.include_role:
+        name: githubixx.cilium_kubernetes

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -1,0 +1,61 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+
+platforms:
+  - name: test-cilium-ubuntu2004
+    box: generic/ubuntu2004
+    memory: 4096
+    cpus: 2
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.10
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+  log: true
+  lint: yamllint . && flake8 && ansible-lint
+  inventory:
+    host_vars:
+      test-cilium-ubuntu2004:
+        ansible_python_interpreter: "/usr/bin/python3"
+        cilium_etcd_enabled: "false"
+        cilium_delegate_to: test-cilium-ubuntu2004
+        cilium_helm_show_commands: true
+        containerd_flavor: "k8s"
+        containerd_tmp_directory: "/tmp"
+        containerd_runc_binary_directory: "/usr/local/sbin"
+        containerd_crictl_config_file: "crictl.yaml"
+        containerd_crictl_config_directory: "/etc"
+        containerd_cni_binary_directory: "/opt/cni/bin"
+        minikube_version: 1.26.1
+        dockerd_settings_user:
+          "log-level": "info"
+          "iptables": "true"
+          "ip-masq": "true"
+          "mtu": "1500"
+
+scenario:
+  name: kvm
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible
+  enabled: true

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -1,0 +1,69 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: ubuntu
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Install support packages
+      ansible.builtin.package:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - conntrack
+          - python3-pip
+
+    - name: Install kubernetes Python package
+      ansible.builtin.pip:
+        name: kubernetes
+        state: present
+
+    - name: Install Docker
+      ansible.builtin.include_role:
+        name: githubixx.docker
+
+    - name: Install containerd
+      ansible.builtin.include_role:
+        name: githubixx.containerd
+
+    - name: Install Helm role
+      ansible.builtin.include_role:
+        name: gantsign.helm
+
+    - name: Install kubectl role
+      ansible.builtin.include_role:
+        name: githubixx.kubectl
+
+    - name: Install Cilium CLI role
+      ansible.builtin.include_role:
+        name: githubixx.cilium_cli
+
+    - name: Install minikube role
+      ansible.builtin.include_role:
+        name: darkwizard242.minikube
+
+    - name: Add user vagrant to docker group
+      ansible.builtin.user:
+        name: vagrant
+        groups: docker
+        append: true
+
+    - name: Reset SSH connection
+      meta: reset_connection
+
+- hosts: ubuntu
+  tasks:
+    - name: Start minikube (could take some time as K8s binaries needs to be downloaded first)
+      ansible.builtin.command:
+        cmd: minikube start --driver=docker --container-runtime=containerd --network-plugin=cni --nodes 3 --install-addons=false
+
+    - name: Delete kindnet DaemonSet
+      ansible.builtin.command:
+        cmd: kubectl -n kube-system delete ds kindnet

--- a/molecule/kvm/requirements.yml
+++ b/molecule/kvm/requirements.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+roles:
+  - gantsign.helm
+  - darkwizard242.minikube

--- a/molecule/kvm/verify.yml
+++ b/molecule/kvm/verify.yml
@@ -1,0 +1,39 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Verify setup
+  hosts: all
+  tasks:
+    - name: Fetch Cilium DaemonSet information
+      k8s_info:
+        api_version: v1
+        kind: DaemonSet
+        name: cilium
+        namespace: cilium
+      register: cilium__daemonset_info
+
+    - name: Print DaemonSet JSON blob
+      ansible.builtin.debug:
+        var: cilium__daemonset_info
+      when: ansible_verbosity > 1
+
+    - name: There should be a DaemonSet called cilium
+      ansible.builtin.assert:
+        that:
+          - cilium__daemonset_info.resources[0].metadata.name == "cilium"
+
+    - name: There should be at least one Cilium pod running
+      ansible.builtin.assert:
+        that:
+          - (cilium__daemonset_info.resources[0].status.numberReady | default(0) | int ) >= 1
+
+    - name: Fetch Cilium status
+      ansible.builtin.command:
+        cmd: cilium -n cilium status
+      register: cilium__status
+
+    - name: Print Cilium status output
+      ansible.builtin.debug:
+        var: cilium__status.stdout
+      when: ansible_verbosity > 1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles:
+  - gantsign.helm

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -1,29 +1,37 @@
 ---
-- name: Delete Cilium resources via Helm
-  ansible.builtin.shell:
-    set -o errexit
-    set -o pipefail
-    set -o nounset
-
-    helm uninstall {{ cilium_release_name }} --namespace {{ cilium_namespace }}
-
-    exit 0
+- name: Uninstall release via Helm
+  kubernetes.core.helm:
+    name: "{{ cilium_release_name }}"
+    release_namespace: "{{ cilium_namespace }}"
+    state: absent
   run_once: true
-  delegate_to: 127.0.0.1
-  changed_when: false
-  args:
-    executable: "/bin/bash"
+  delegate_to: "{{ cilium_delegate_to }}"
+  register: cilium__helm_show_uninstall_release
+
+- name: Uninstall release via Helm (helm command executed)
+  when:
+    - cilium__helm_show_uninstall_release is defined
+    - cilium__helm_show_uninstall_release.command is defined
+    - cilium_helm_show_commands
+  ansible.builtin.debug:
+    var: cilium__helm_show_uninstall_release.command
+  delegate_to: "{{ cilium_delegate_to }}"
+  run_once: true
 
 - name: Delete Cilium etcd secrets in k8s
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', 'etcd-secrets.yml.j2') }}"
+    name: "{{ cilium_etcd_secrets_name }}"
     namespace: "{{ cilium_namespace }}"
-  delegate_to: 127.0.0.1
+    api_version: v1
+    kind: Secret
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
-  when: cilium_etcd_secrets_name is defined
 
 - name: BPFFS handling for Ubuntu 18.04
+  when:
+    - ansible_lsb.release is defined
+    - ansible_lsb.release is version('20.04', '<')
   block:
     - name: Disable and umount BPFFS
       ansible.builtin.service:
@@ -37,9 +45,6 @@
         state: absent
       notify:
         - Reload systemd
-  when:
-    - ansible_lsb.release is defined
-    - ansible_lsb.release is version('20.04', '<')
 
 - name: Delete namespace used by Cilium
   kubernetes.core.k8s:
@@ -47,5 +52,5 @@
     api_version: v1
     kind: Namespace
     state: absent
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true

--- a/tasks/helm_repository.yml
+++ b/tasks/helm_repository.yml
@@ -1,17 +1,20 @@
 ---
-- name: Register if Cilium Helm repository is installed
-  ansible.builtin.command: helm search repo {{ cilium_repo_name }} -n {{ cilium_namespace }} --version ^{{ cilium_chart_version }} 2>/dev/null
-  register: cilium_repo_installed
-  changed_when: false
-  delegate_to: 127.0.0.1
+- name: Add Helm repository
+  when:
+    - cilium__helm_repo_installed.status is not defined
+  kubernetes.core.helm_repository:
+    name: "{{ cilium_repo_name }}"
+    repo_url: "{{ cilium_chart_url }}"
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
-  ignore_errors: true
+  register: cilium__helm_add_repo
 
-- name: Add cilium helm repository
-  ansible.builtin.command: helm repo add {{ cilium_repo_name }} {{ cilium_chart_url }}
-  changed_when: false
-  delegate_to: 127.0.0.1
+- name: Add Helm repository (helm command executed)
+  when:
+    - cilium__helm_add_repo is defined
+    - cilium__helm_add_repo.command is defined
+    - cilium_helm_show_commands
+  ansible.builtin.debug:
+    var: cilium__helm_add_repo.command
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
-  when: |
-    cilium_repo_installed.failed or
-    cilium_repo_installed.stdout.find(cilium_repo_name) == -1

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,7 +5,7 @@
     api_version: v1
     kind: Namespace
     state: present
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
 
 - name: Include Helm repository tasks
@@ -13,6 +13,9 @@
     file: helm_repository.yml
 
 - name: BPFFS handling for Ubuntu 18.04
+  when:
+    - ansible_lsb.release is defined
+    - ansible_lsb.release is version('20.04', '<')
   block:
     - name: Install systemd unit file for mounting BPFFS
       ansible.builtin.copy:
@@ -29,18 +32,18 @@
         name: sys-fs-bpf.mount
         enabled: true
         state: started
-  when:
-    - ansible_lsb.release is defined
-    - ansible_lsb.release is version('20.04', '<')
 
 - name: Install Cilium etcd secrets in k8s
+  when:
+    - cilium_etcd_enabled is defined
+    - cilium_etcd_enabled == "true"
+    - cilium_etcd_secrets_name is defined
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'etcd-secrets.yml.j2') }}"
     namespace: "{{ cilium_namespace }}"
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
-  when: cilium_etcd_secrets_name is defined
 
 - name: Install Cilium via Helm
   block:
@@ -48,16 +51,16 @@
       ansible.builtin.tempfile:
         state: file
         suffix: cilium_values
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
       run_once: true
-      register: cilium_values_tmp_file
+      register: cilium__values_tmp_file
 
     - name: Select values file for Helm template
       ansible.builtin.template:
         src: "{{ lookup('first_found', params) }}"
-        dest: "{{ cilium_values_tmp_file.path }}"
+        dest: "{{ cilium__values_tmp_file.path }}"
         mode: 0600
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
       run_once: true
       vars:
         params:
@@ -67,37 +70,43 @@
           paths:
             - templates
 
-    - name: Install Cilium
-      ansible.builtin.shell:
-        set -o errexit
-        set -o pipefail
-        set -o nounset
-
-        helm install {{ cilium_release_name }} {{ cilium_chart_name }}
-        --namespace {{ cilium_namespace }}
-        --version {{ cilium_chart_version }}
-        --values {{ cilium_values_tmp_file.path }}
-
-        exit 0
+    - name: Install chart
+      kubernetes.core.helm:
+        name: "{{ cilium_release_name }}"
+        chart_ref: "{{ cilium_chart_name }}"
+        chart_version: "{{ cilium_chart_version }}"
+        release_namespace: "{{ cilium_namespace }}"
+        create_namespace: false
+        update_repo_cache: true
+        values_files:
+          - "{{ cilium__values_tmp_file.path }}"
       run_once: true
-      delegate_to: 127.0.0.1
-      changed_when: false
-      args:
-        executable: "/bin/bash"
+      delegate_to: "{{ cilium_delegate_to }}"
+      register: cilium__helm_install_chart
+
+    - name: Install chart (helm command executed)
+      when:
+        - cilium__helm_install_chart is defined
+        - cilium__helm_install_chart.command is defined
+        - cilium_helm_show_commands
+      ansible.builtin.debug:
+        var: cilium__helm_install_chart.command
+      delegate_to: "{{ cilium_delegate_to }}"
+      run_once: true
 
     - name: Delete temporary file for Helm values
+      when: cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
+      delegate_to: "{{ cilium_delegate_to }}"
 
   rescue:
     - name: Delete temporary file for Helm values
+      when: cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
+      delegate_to: "{{ cilium_delegate_to }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if Helm command is installed locally
   ansible.builtin.shell: hash helm
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
   changed_when: false
   args:
@@ -10,13 +10,13 @@
 - name: Set default action to only render template via Helm
   ansible.builtin.set_fact:
     deploy_action: "template"
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
 
 - name: Set action to install via Helm
   ansible.builtin.set_fact:
     deploy_action: "install"
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
   when:
     - action is defined
@@ -25,7 +25,7 @@
 - name: Set action to upgrade via Helm
   ansible.builtin.set_fact:
     deploy_action: "upgrade"
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
   when:
     - action is defined
@@ -34,7 +34,7 @@
 - name: Set action to delete via Helm
   ansible.builtin.set_fact:
     deploy_action: "delete"
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
   when:
     - action is defined

--- a/tasks/pre_flight_check.yml
+++ b/tasks/pre_flight_check.yml
@@ -1,10 +1,11 @@
+---
 - name: Pre flight pod check
   block:
     - name: Set the retry count
       ansible.builtin.set_fact:
         retry_count: "{{ 0 if retry_count is undefined else retry_count | int + 1 }}"
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Waiting for pre flight deployment
       ansible.builtin.wait_for:
@@ -19,41 +20,41 @@
         namespace: "{{ cilium_namespace }}"
       register: cilium_pre_flight_check_daemonset
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Register current Cilium pre flight pods running
       ansible.builtin.set_fact:
-        cilium_pre_flight_pods_running="{{ cilium_pre_flight_check_daemonset | json_query(query) }}"
+        cilium_pre_flight_pods_running: "{{ cilium_pre_flight_check_daemonset | json_query(query) }}"
       vars:
         query: "resources[0].status.numberReady"
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Checking if Cilium pre flight pod count == Cilium pod count
       ansible.builtin.fail:
         msg: "Pre flight count: {{ cilium_pre_flight_pods_running }} / Cilium count: {{ cilium_pods_running }}"
       when: cilium_pre_flight_pods_running | int != cilium_pods_running | int
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
   rescue:
     - name: Fail if retry count is reached
       ansible.builtin.fail:
         msg: Ended after 60 retries
       when: retry_count | int == 60
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Preflight waiting loop
       ansible.builtin.debug:
         msg: "Waiting for Cilium pre flight pods starting up..."
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Sleeping
       ansible.builtin.wait_for:
         timeout: 10
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Include pre flight checks
       ansible.builtin.include_tasks:

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -9,16 +9,16 @@
       ansible.builtin.tempfile:
         state: file
         suffix: cilium_values
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
       run_once: true
-      register: cilium_values_tmp_file
+      register: cilium__values_tmp_file
 
     - name: Select values file for Helm template
       ansible.builtin.template:
         src: "{{ lookup('first_found', params) }}"
-        dest: "{{ cilium_values_tmp_file.path }}"
+        dest: "{{ cilium__values_tmp_file.path }}"
         mode: 0600
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
       run_once: true
       vars:
         params:
@@ -28,45 +28,57 @@
           paths:
             - templates
 
-    - name: Render Cilium template
-      ansible.builtin.shell:
-        set -o errexit
-        set -o pipefail
-        set -o nounset
+    - name: Render template
+      kubernetes.core.helm_template:
+        chart_ref: "{{ cilium_chart_name }}"
+        chart_version: "{{ cilium_chart_version }}"
+        release_namespace: "{{ cilium_namespace }}"
+        update_repo_cache: true
+        values_files:
+          - "{{ cilium__values_tmp_file.path }}"
+      run_once: true
+      delegate_to: "{{ cilium_delegate_to }}"
+      register: cilium__template
 
-        helm template {{ cilium_release_name }} {{ cilium_chart_name }}
-        --namespace {{ cilium_namespace }}
-        --version {{ cilium_chart_version }}
-        --values {{ cilium_values_tmp_file.path }}
+    - name: Render template (helm command executed)
+      when:
+        - cilium__template is defined
+        - cilium__template.command is defined
+        - cilium_helm_show_commands
+      ansible.builtin.debug:
+        var: cilium__template.command
+      delegate_to: "{{ cilium_delegate_to }}"
+      run_once: true
 
-        exit 0
+    - name: Create directory to store template.yml
+      ansible.builtin.file:
+        dest: "{{ cilium_template_output_directory }}"
+        state: directory
+        mode: 0755
       run_once: true
       delegate_to: 127.0.0.1
-      register: cilium_template
-      changed_when: false
-      args:
-        executable: "/bin/bash"
+
+    - name: Write templates to file
+      ansible.builtin.copy:
+        dest: "{{ cilium_template_output_directory }}/template.yml"
+        content: "{{ cilium__template.stdout }}"
+        mode: 0644
+      run_once: true
+      delegate_to: 127.0.0.1
 
     - name: Delete temporary file for Helm values
+      when: cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
-
-    - name: Output rendered template
-      ansible.builtin.debug:
-        msg: "{{ cilium_template.stdout }}"
-      run_once: true
-      delegate_to: 127.0.0.1
-      changed_when: false
+      delegate_to: "{{ cilium_delegate_to }}"
 
   rescue:
     - name: Delete temporary file for Helm values
+      when: cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
+      delegate_to: "{{ cilium_delegate_to }}"

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,27 +1,15 @@
 ---
 - name: Ensure Cilium etcd secrets in k8s
+  when:
+    - cilium_etcd_enabled is defined
+    - cilium_etcd_enabled == "true"
+    - cilium_etcd_secrets_name is defined
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'etcd-secrets.yml.j2') }}"
     namespace: "{{ cilium_namespace }}"
-  delegate_to: 127.0.0.1
   run_once: true
-  when: cilium_etcd_secrets_name is defined
-
-- name: Update Helm repo
-  ansible.builtin.shell:
-    set -o errexit
-    set -o pipefail
-    set -o nounset
-
-    helm repo update
-
-    exit 0
-  run_once: true
-  delegate_to: 127.0.0.1
-  changed_when: false
-  args:
-    executable: "/bin/bash"
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Fetch current Cilium DaemonSet information
   kubernetes.core.k8s_info:
@@ -29,17 +17,17 @@
     kind: DaemonSet
     name: "{{ cilium_release_name }}"
     namespace: "{{ cilium_namespace }}"
-  register: cilium_daemonset
+  register: cilium__daemonset
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Register current Cilium pods running
   ansible.builtin.set_fact:
-    cilium_pods_running="{{ cilium_daemonset | json_query(query) }}"
+    cilium_pods_running: "{{ cilium__daemonset | json_query(query) }}"
   vars:
     query: "resources[0].status.numberReady"
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Fetch information if there is a Cilium pre-flight check deployment leftover
   kubernetes.core.k8s_info:
@@ -47,60 +35,65 @@
     kind: Deployment
     name: cilium-pre-flight-check
     namespace: "{{ cilium_namespace }}"
-  register: cilium_pre_flight_check_deployment
+  register: cilium__pre_flight_check_deployment
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Register if there is a Cilium pre-flight check deployment leftover
   ansible.builtin.set_fact:
-    cilium_pre_flight_check_leftover="{{ cilium_pre_flight_check_deployment | json_query(query) }}"
+    cilium_pre_flight_check_leftover: "{{ cilium__pre_flight_check_deployment | json_query(query) }}"
   vars:
     query: "resources[0].metadata.name"
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Delete Cilium pre-flight check leftover
-  ansible.builtin.shell:
-    set -o errexit
-    set -o pipefail
-    set -o nounset
-
-    helm delete cilium-preflight
-      --namespace {{ cilium_namespace }}
-
-    exit 0
-  run_once: true
-  delegate_to: 127.0.0.1
+  when:
+    - cilium_pre_flight_check_leftover.find("cilium-pre-flight-check") != -1
+  kubernetes.core.helm:
+    name: "cilium-preflight"
+    release_namespace: "{{ cilium_namespace }}"
+    state: absent
   changed_when: false
-  when: cilium_pre_flight_check_leftover.find("cilium-pre-flight-check") != -1
-  args:
-    executable: "/bin/bash"
+  run_once: true
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Give Kubernetes 30 secs to delete Cilium pre-flight check
+  when:
+    - cilium_pre_flight_check_leftover.find("cilium-pre-flight-check") != -1
   ansible.builtin.wait_for:
     timeout: 30
-  when: cilium_pre_flight_check_leftover.find("cilium-pre-flight-check") != -1
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Install Cilium pre-flight check
-  ansible.builtin.shell:
-    set -o errexit
-    set -o pipefail
-    set -o nounset
-
-    helm install cilium-preflight {{ cilium_chart_name }} --version {{ cilium_chart_version }}
-      --namespace {{ cilium_namespace }}
-      --set preflight.enabled=true
-      --set agent=false
-      --set operator.enabled=false
-
-    exit 0
-  run_once: true
-  delegate_to: 127.0.0.1
+  kubernetes.core.helm:
+    name: "cilium-preflight"
+    chart_ref: "{{ cilium_chart_name }}"
+    chart_version: "{{ cilium_chart_version }}"
+    release_namespace: "{{ cilium_namespace }}"
+    create_namespace: false
+    update_repo_cache: true
+    values:
+      agent: false
+      preflight:
+        enabled: true
+      operator:
+        enabled: false
   changed_when: false
-  args:
-    executable: "/bin/bash"
+  run_once: true
+  delegate_to: "{{ cilium_delegate_to }}"
+  register: cilium__helm_pre_flight
+
+- name: Install Cilium pre-flight check (helm command executed)
+  when:
+    - cilium__helm_pre_flight is defined
+    - cilium__helm_pre_flight.command is defined
+    - cilium_helm_show_commands
+  ansible.builtin.debug:
+    var: cilium__helm_pre_flight.command
+  run_once: true
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Waiting for pre flight check to be deployed
   ansible.builtin.include_tasks:
@@ -112,48 +105,53 @@
     kind: Deployment
     name: cilium-pre-flight-check
     namespace: "{{ cilium_namespace }}"
-  register: cilium_pre_flight_deployment
+  register: cilium__pre_flight_deployment
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Register Cilium pre flight ready replicas
   ansible.builtin.set_fact:
-    cilium_pre_flight_ready_replicas="{{ cilium_pre_flight_deployment | json_query(query) }}"
+    cilium_pre_flight_ready_replicas: "{{ cilium__pre_flight_deployment | json_query(query) }}"
   vars:
     query: "resources[0].status.readyReplicas"
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Register Cilium pre flight replicas
   ansible.builtin.set_fact:
-    cilium_pre_flight_replicas="{{ cilium_pre_flight_deployment | json_query(query) }}"
+    cilium_pre_flight_replicas: "{{ cilium__pre_flight_deployment | json_query(query) }}"
   vars:
     query: "resources[0].status.replicas"
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Check replica count == ready replicas
+  when:
+    - cilium_pre_flight_replicas | int != cilium_pre_flight_ready_replicas | int
   ansible.builtin.fail:
     msg: "Replica count ({{ cilium_pre_flight_replicas }}) != ready replicas count ({{ cilium_pre_flight_ready_replicas }})"
-  when: cilium_pre_flight_replicas | int != cilium_pre_flight_ready_replicas | int
   run_once: true
-  delegate_to: 127.0.0.1
+  delegate_to: "{{ cilium_delegate_to }}"
 
 - name: Delete Cilium pre flight via Helm
-  ansible.builtin.shell:
-    set -o errexit
-    set -o pipefail
-    set -o nounset
-
-    helm delete cilium-preflight
-      --namespace {{ cilium_namespace }}
-
-    exit 0
-  run_once: true
-  delegate_to: 127.0.0.1
+  kubernetes.core.helm:
+    name: "cilium-preflight"
+    release_namespace: "{{ cilium_namespace }}"
+    state: absent
   changed_when: false
-  args:
-    executable: "/bin/bash"
+  run_once: true
+  delegate_to: "{{ cilium_delegate_to }}"
+  register: cilium__helm_pre_flight_chart
+
+- name: Delete Cilium pre flight via Helm (helm command executed)
+  when:
+    - cilium__helm_pre_flight_chart is defined
+    - cilium__helm_pre_flight_chart.command is defined
+    - cilium_helm_show_commands
+  ansible.builtin.debug:
+    var: cilium__helm_pre_flight_chart.command
+  delegate_to: "{{ cilium_delegate_to }}"
+  run_once: true
 
 - name: Upgrade Cilium via Helm
   block:
@@ -161,17 +159,17 @@
       ansible.builtin.tempfile:
         state: file
         suffix: cilium_values
-      delegate_to: 127.0.0.1
       run_once: true
-      register: cilium_values_tmp_file
+      delegate_to: "{{ cilium_delegate_to }}"
+      register: cilium__values_tmp_file
 
     - name: Select values file for Helm template
       ansible.builtin.template:
         src: "{{ lookup('first_found', params) }}"
-        dest: "{{ cilium_values_tmp_file.path }}"
+        dest: "{{ cilium__values_tmp_file.path }}"
         mode: 0600
-      delegate_to: 127.0.0.1
       run_once: true
+      delegate_to: "{{ cilium_delegate_to }}"
       vars:
         params:
           files:
@@ -180,37 +178,48 @@
           paths:
             - templates
 
-    - name: Install Cilium
-      ansible.builtin.shell:
-        set -o errexit
-        set -o pipefail
-        set -o nounset
-
-        helm upgrade {{ cilium_release_name }} {{ cilium_chart_name }}
-        --namespace {{ cilium_namespace }}
-        --version {{ cilium_chart_version }}
-        --values {{ cilium_values_tmp_file.path }}
-
-        exit 0
+    - name: Upgrade Helm chart
+      kubernetes.core.helm:
+        name: "{{ cilium_release_name }}"
+        chart_ref: "{{ cilium_chart_name }}"
+        chart_version: "{{ cilium_chart_version }}"
+        release_namespace: "{{ cilium_namespace }}"
+        create_namespace: false
+        update_repo_cache: true
+        values_files:
+          - "{{ cilium__values_tmp_file.path }}"
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
+      register: cilium__helm_upgrade_chart
+
+    - name: Upgrade Helm chart (helm command executed)
+      when:
+        - cilium__helm_upgrade_chart is defined
+        - cilium__helm_upgrade_chart.command is defined
+        - cilium_helm_show_commands
+      ansible.builtin.debug:
+        var: cilium__helm_upgrade_chart.command
       changed_when: false
-      args:
-        executable: "/bin/bash"
+      run_once: true
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Delete temporary file for Helm values
+      when:
+        - cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
+      changed_when: false
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
+      delegate_to: "{{ cilium_delegate_to }}"
 
   rescue:
     - name: Delete temporary file for Helm values
+      when:
+        - cilium__values_tmp_file.path is defined
       ansible.builtin.file:
-        path: "{{ cilium_values_tmp_file.path }}"
+        path: "{{ cilium__values_tmp_file.path }}"
         state: absent
       run_once: true
-      delegate_to: 127.0.0.1
-      when: cilium_values_tmp_file.path is defined
+      delegate_to: "{{ cilium_delegate_to }}"
+      changed_when: false


### PR DESCRIPTION
- upgrade to Cilium `v1.12.3`
- introduce `cilium_delegate_to` variable. Previously this was hard coded to `127.0.0.1` and it's also the default of this variable.
- introduce `cilium_helm_show_commands` variable (see README for more information)
- introduce `cilium_template_output_directory` variable (see README for more information)
- introduce `Molecule` tests
- don't use `shell` module anymore to execute `helm` command. Now `kubernetes.core.helm*` modules are used.
- use two underscores for internal variables
- ansible-lint: fix various issues like using FQDN Ansible module names now
- add `requirements.yml`
- add `collections.yml`