### PR TITLE
9.0.0+1.12.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Copyright (C) 2018-2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+molecule/kvm/.vagrant
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2022 Robert Wimmer
+# Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 molecule/kvm/.vagrant

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 150
+    level: warning
+
+  comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,39 @@
-Changelog
----------
+# Changelog
 
-**8.0.0+1.12.3**
+## 9.0.0+1.12.5
 
-- upgrade to Cilium v1.12.3
+- **BREAKING**: The `action` variable was renamed to `cilium_action` variable. This avoids variable collisions with other roles.
+- **BREAKING**: Allow to set Helm values for pre-flight-check in `cilium_values_user_pre_flight_check.yml.j2` or `cilium_values_default_pre_flight_check.yml.j2` templates. In previous versions these values were hard-coded in `tasks/upgrade.yml`. This change comes together with the next one:
+- **BREAKING**: In previous versions the Helm values for pre-flight-check were:
+
+```yaml
+agent: false
+preflight:
+  enabled: true
+operator:
+  enabled: false
+```
+
+This was changed to:
+
+```yaml
+agent: false
+preflight:
+  enabled: true
+  tolerations:
+    - operator: Exists
+operator:
+  enabled: false
+```
+
+By default Cilium gets installed on all nodes including the control plane nodes. That's because the `toleration` is set to `operator: Exists` which ignores all taints set on all Kubernetes nodes. Since the "pre-flight-check" expects that the number of current Cilium pods equals the number of "pre-flight-check" pods, the "pre-flight-check" pods needs to run on all nodes where the current Cilium pods are running. The default Helm chart values disallow running "pre-flight-check" pods running on the control-plane nodes. If you've different taints you might need to adjust the "pre-flight-check" tolerations.
+
+- upgrade to Cilium `v1.12.5`
+- added `.gitignore`
+
+## 8.0.0+1.12.3
+
+- upgrade to Cilium `v1.12.3`
 - introduce `cilium_delegate_to` variable. Previously this was hard coded to `127.0.0.1` and it's also the default of this variable.
 - introduce `cilium_helm_show_commands` variable (see README for more information)
 - introduce `cilium_template_output_directory` variable (see README for more information)
@@ -14,73 +44,73 @@ Changelog
 - add `requirements.yml`
 - add `collections.yml`
 
-**7.1.1+1.12.1**
+## 7.1.1+1.12.1
 
 - fix YAML syntax in `tasks/main.yml`
 - use FQN Ansible module names for `include_tasks`
 
-**7.1.0+1.12.1**
+## 7.1.0+1.12.1
 
 - fix various ansible-lint issues
 
-**7.0.0+1.12.1**
- 
-- upgrade to Cilium v1.12.1
+## 7.0.0+1.12.1
+
+- upgrade to Cilium `v1.12.1`
 - add Github release action to push new release to Ansible Galaxy
 
-**6.0.4+1.11.6**
+## 6.0.4+1.11.6
 
-- upgrade to Cilium v1.11.6
+- upgrade to Cilium `v1.11.6`
 
-**6.0.3+1.11.5**
+## 6.0.3+1.11.5
 
-- upgrade to Cilium v1.11.5
+- upgrade to Cilium `v1.11.5`
 
-**6.0.2+1.11.4**
+## 6.0.2+1.11.4
 
-- upgrade to Cilium v1.11.4
+- upgrade to Cilium `v1.11.4`
 
-**6.0.1+1.11.1**
+## 6.0.1+1.11.1
 
-- upgrade to Cilium v1.11.1
+- upgrade to Cilium `v1.11.1`
 - make sure Cilium Helm chart is installed before rendering (contribution by @tiagoblackcode)
 
-**6.0.0+1.11.0**
+## 6.0.0+1.11.0
 
-- upgrade to Cilium v1.11.0
+- upgrade to Cilium `v1.11.0`
 - remove unneeded directories
 - fix some linting issues
 
-**5.1.0+1.10.4**
+## 5.1.0+1.10.4
 
 - upgrade to Cilium v1.10.4
 - add `bpf.masquerade: true` option to enable native IP masquerade support in eBPF. The eBPF-based masquerading implementation is the most efficient implementation. It requires Linux kernel >= 4.19. See: [Cilium Masquerading](https://docs.cilium.io/en/stable/concepts/networking/masquerading/)
 
-**5.0.0+1.10.1**
+## 5.0.0+1.10.1
 
 - upgrade to Cilium v1.10.1
 
-**4.0.1+1.9.7**
+## 4.0.1+1.9.7
 
 - upgrade to Cilium v1.9.7
 
-**4.0.0+1.9.1**
+## 4.0.0+1.9.1
 
 - introduce variables `cilium_release_name` and `cilium_repo_name`
 - `cilium_chart_name` had the wrong value. The `cilium_chart_name` was actually the `cilium_release_name`. If you used the default `cilium_chart_name: "cilium"` nothing will change for you. Otherwise you may need `cilium_release_name`, `cilium_repo_name` and `cilium_chart_name` accordingly.
 
-**3.0.0+1.9.1**
+## 3.0.0+1.9.1
 
 - upgrade to Cilium v1.9.1
 - refactor `cilium_values_default.yml.j2` because re-scoped in Cilium v1.9 (see [1.9 Upgrade Notes](https://docs.cilium.io/en/v1.9/operations/upgrade/#upgrade-notes) and [values.yaml](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml)). Esp. value names like `agent.*`, `config.*` and `global.*` have changed.
 - small changes in Helm values for pre-flight check
 - rename extra vars `cilium_(install|upgrade|delete)=true` to `action=(install|upgrade|delete)`
 
-**2.0.0+1.8.4**
+## 2.0.0+1.8.4
 
 - upgrade to Cilium v1.8.4
 
-**2.0.0+1.8.1**
+## 2.0.0+1.8.1
 
 - upgrade to Cilium v1.8.1
 - handle Cilium pre-flight check leftover
@@ -88,10 +118,10 @@ Changelog
 - `upgradeCompatibility` variable value needs to be string
 - increase retries for pre-flight-check from 30 to 60
 
-**1.0.1+1.7.4**
+## 1.0.1+1.7.4
 
 - formatting / make ansible-lint happy
 
-**1.0.0+1.7.4**
+## 1.0.0+1.7.4
 
 - initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ By default Cilium gets installed on all nodes including the control plane nodes.
 
 - upgrade to Cilium `v1.12.5`
 - added `.gitignore`
+- added `.yamlint`
 
 ## 8.0.0+1.12.3
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role installs [Cilium](https://docs.cilium.io) network on a Kuberne
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `8.0.0+1.12.3` means this is release `8.0.0` of this role and it contains Cilium chart version `1.12.3`. If the role itself changes `X.Y.Z` before `+` will increase. If the Cilium chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Cilium release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `9.0.0+1.12.5` means this is release `9.0.0` of this role and it contains Cilium chart version `1.12.5`. If the role itself changes `X.Y.Z` before `+` will increase. If the Cilium chart version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Cilium release.
 
 Requirements
 ------------
@@ -28,7 +28,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cilium_chart_version: "1.12.3"
+cilium_chart_version: "1.12.5"
 
 # Helm chart name
 cilium_chart_name: "cilium"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ As [Cilium](https://docs.cilium.io) issues updates/upgrades every few weeks/mont
 
 If a upgrade wasn't successful a [Roll back](https://docs.cilium.io/en/v1.12/operations/upgrade/#step-3-rolling-back) to a previous version can be basically initiated by just changing `cilium_chart_version` variable. But you should definitely read the Cilium [roll back guide](https://docs.cilium.io/en/v1.12/operations/upgrade/#step-3-rolling-back). Switching between minor releases is normally not an issue but switching from one major release to a previous one might be not so easy.
 
+Also check `templates/cilium_values_default_pre_flight_check.yml.j2`. If you need to adjust values for the `pre-flight` check you can either change that file or create a file `templates/cilium_values_user_pre_flight_check.yml.j2` with your own values.
+
 Before doing the upgrade you basically only need to change `cilium_chart_version` variable e.g. from `1.10.10` to `1.11.4` to upgrade from `1.10.10` to `1.11.4`. So to do the update run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ And of course you need a Kubernetes Cluster ;-)
 Role Variables
 --------------
 
-```
+```yaml
 # Helm chart version
 cilium_chart_version: "1.12.3"
 
@@ -111,8 +111,8 @@ cilium_helm_show_commands: false
 cilium_template_output_directory: "{{ '~/cilium/template' | expanduser }}"
 ```
 
-Usage:
-------
+Usage
+-----
 
 The first thing to do is to check `templates/cilium_values_default.yml.j2`. This file contains the values/settings for the Cilium Helm chart that are different to the default ones which are located [here](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml). The default values of this Ansible role are using a TLS enabled `etcd` cluster. If you have a self hosted/bare metal Kubernetes cluster chances are high that there is already running an `etcd` cluster for the Kubernetes API server which is the case for me. I'm using my Ansible [etcd role](https://github.com/githubixx/ansible-role-etcd) to install such an `etcd` cluster and my [Kubernetes Certificate Authority role](https://github.com/githubixx/ansible-role-kubernetes-ca) to generate the certificates. So if you used my roles you can use this Cilium role basically as is.
 
@@ -122,9 +122,9 @@ But nothing is made in stone ;-) To use your own values just create a file calle
 
 After the values file (`templates/cilium_values_default.yml.j2` or `templates/cilium_values_user.yml.j2`) is in place and the `defaults/main.yml` values are checked the role can be installed. Most of the role's tasks are executed locally by default so to say as quite a few tasks need to communicate with the Kubernetes API server or executing [Helm](https://helm.sh/) commands. But you can delegate this kind of tasks to a different host by using `cilium_delegate_to` variable (see above).
 
-The default action is to just render the Kubernetes resources YAML file after replacing all Jinja2 variables and stuff like that. In the `Example Playbook` section below there is an `Example 2 (assign tag to role)`. The role `githubixx.cilium-kubernetes` has a tag `role-cilium-kubernetes` assigned. Assuming that the values for the Helm chart should be rendered (nothing will be installed in this case) and the playbook is called `k8s.yml` execute the following command:
+The default action is to just render the Kubernetes resources YAML file after replacing all Jinja2 variables and stuff like that. In the `Example Playbook` section below there is an `Example 2 (assign tag to role)`. The role `githubixx.cilium_kubernetes` has a tag `role-cilium-kubernetes` assigned. Assuming that the values for the Helm chart should be rendered (nothing will be installed in this case) and the playbook is called `k8s.yml` execute the following command:
 
-```
+```bash
 ansible-playbook --tags=role-cilium-kubernetes k8s.yml
 ```
 
@@ -140,7 +140,7 @@ One of the final tasks is called `TASK [githubixx.cilium_kubernetes : Write temp
 
 If the rendered output contains everything you need the role can be installed which finally deploys Cilium:
 
-```
+```bash
 ansible-playbook --tags=role-cilium-kubernetes --extra-vars action=install k8s.yml
 ```
 
@@ -150,7 +150,7 @@ As [Cilium](https://docs.cilium.io) issues updates/upgrades every few weeks/mont
 
 Before doing the upgrade you basically only need to change `cilium_chart_version` variable e.g. from `1.10.10` to `1.11.4` to upgrade from `1.10.10` to `1.11.4`. So to do the update run
 
-```
+```bash
 ansible-playbook --tags=role-cilium-kubernetes --extra-vars action=upgrade k8s.yml
 ```
 
@@ -158,7 +158,7 @@ As already mentioned the role already includes some checks to make sure the upgr
 
 And finally if you want to get rid of Cilium you can delete all resources again:
 
-```
+```bash
 ansible-playbook --tags=role-cilium-kubernetes --extra-vars action=delete k8s.yml
 ```
 
@@ -168,19 +168,21 @@ Example Playbook
 ----------------
 
 Example 1 (without role tag):
-```
+
+```yaml
 - hosts: k8s_worker
   roles:
-    - githubixx.cilium-kubernetes
+    - githubixx.cilium_kubernetes
 ```
 
 Example 2 (assign tag to role):
-```
+
+```yaml
 -
   hosts: k8s_worker
   roles:
     -
-      role: githubixx.cilium-kubernetes
+      role: githubixx.cilium_kubernetes
       tags: role-cilium-kubernetes
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Helm chart version (uses Cilium v1.12.3)
-cilium_chart_version: "1.12.3"
+# Helm chart version (uses Cilium v1.12.5)
+cilium_chart_version: "1.12.5"
 
 # Helm release name
 cilium_release_name: "cilium"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,39 +7,14 @@
   args:
     executable: "/bin/bash"
 
-- name: Set default action to only render template via Helm
-  ansible.builtin.set_fact:
-    deploy_action: "template"
-  delegate_to: "{{ cilium_delegate_to }}"
-  run_once: true
-
-- name: Set action to install via Helm
-  ansible.builtin.set_fact:
-    deploy_action: "install"
-  delegate_to: "{{ cilium_delegate_to }}"
-  run_once: true
+- name: Set action according to cilium_action variable
   when:
-    - action is defined
-    - '"install" in action'
-
-- name: Set action to upgrade via Helm
+    - cilium_action is not defined
   ansible.builtin.set_fact:
-    deploy_action: "upgrade"
+    cilium_action: "template"
   delegate_to: "{{ cilium_delegate_to }}"
   run_once: true
-  when:
-    - action is defined
-    - '"upgrade" in action'
-
-- name: Set action to delete via Helm
-  ansible.builtin.set_fact:
-    deploy_action: "delete"
-  delegate_to: "{{ cilium_delegate_to }}"
-  run_once: true
-  when:
-    - action is defined
-    - '"delete" in action'
 
 - name: Include tasks to execute requested action
   ansible.builtin.include_tasks:
-    file: "tasks/{{ deploy_action | lower }}.yml"
+    file: "tasks/{{ cilium_action | lower }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check if Helm command is installed locally
+- name: Check if Helm command is installed
   ansible.builtin.shell: hash helm
   delegate_to: "{{ cilium_delegate_to }}"
   run_once: true

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -56,7 +56,7 @@
         state: directory
         mode: 0755
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Write templates to file
       ansible.builtin.copy:
@@ -64,7 +64,7 @@
         content: "{{ cilium__template.stdout }}"
         mode: 0644
       run_once: true
-      delegate_to: 127.0.0.1
+      delegate_to: "{{ cilium_delegate_to }}"
 
     - name: Delete temporary file for Helm values
       when: cilium__values_tmp_file.path is defined

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -74,12 +74,14 @@
     release_namespace: "{{ cilium_namespace }}"
     create_namespace: false
     update_repo_cache: true
-    values:
-      agent: false
-      preflight:
-        enabled: true
-      operator:
-        enabled: false
+    values: "{{ lookup('template', lookup('first_found', params)) | from_yaml }}"
+  vars:
+    params:
+      files:
+        - cilium_values_user_pre_flight_check.yml.j2
+        - cilium_values_default_pre_flight_check.yml.j2
+      paths:
+        - templates
   changed_when: false
   run_once: true
   delegate_to: "{{ cilium_delegate_to }}"

--- a/templates/cilium_values_default_pre_flight_check.yml.j2
+++ b/templates/cilium_values_default_pre_flight_check.yml.j2
@@ -1,0 +1,7 @@
+agent: false
+preflight:
+  enabled: true
+  tolerations:
+    - operator: Exists
+operator:
+  enabled: false


### PR DESCRIPTION
- **BREAKING**: The `action` variable was renamed to `cilium_action` variable. This avoids variable collisions with other roles.
- **BREAKING**: Allow to set Helm values for pre-flight-check in `cilium_values_user_pre_flight_check.yml.j2` or `cilium_values_default_pre_flight_check.yml.j2` templates. In previous versions these values were hard-coded in `tasks/upgrade.yml`. This change comes together with the next one:
- **BREAKING**: In previous versions the Helm values for pre-flight-check were:

```yaml
agent: false
preflight:
  enabled: true
operator:
  enabled: false
```

This was changed to:

```yaml
agent: false
preflight:
  enabled: true
  tolerations:
    - operator: Exists
operator:
  enabled: false
```

By default Cilium gets installed on all nodes including the control plane nodes. That's because the `toleration` is set to `operator: Exists` which ignores all taints set on all Kubernetes nodes. Since the "pre-flight-check" expects that the number of current Cilium pods equals the number of "pre-flight-check" pods, the "pre-flight-check" pods needs to run on all nodes where the current Cilium pods are running. The default Helm chart values disallow running "pre-flight-check" pods running on the control-plane nodes. If you've different taints you might need to adjust the "pre-flight-check" tolerations.

- upgrade to Cilium `v1.12.5`
- added `.gitignore`
- added 'yamlint'