### PR TITLE
10.0.0+1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 10.0.0+1.13.0
+
+- upgrade to Cilium `v1.13.0`. Please check [](https://docs.cilium.io/en/v1.13/operations/upgrade/#current-release-required-changes) for possible incompatible changes and deprecations.
+- `tasks/pre_flight_check.yml` + `upgrade.yml`: fix ansible-lint issues
+
 ## 9.0.0+1.12.5
 
 - **BREAKING**: The `action` variable was renamed to `cilium_action` variable. This avoids variable collisions with other roles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.0.0+1.13.0
 
 - upgrade to Cilium `v1.13.0`. Please check [](https://docs.cilium.io/en/v1.13/operations/upgrade/#current-release-required-changes) for possible incompatible changes and deprecations.
+- added `force:true` in case of Helm chart upgrade to make sure the upgrade happens no matter what
 - `tasks/pre_flight_check.yml` + `upgrade.yml`: fix ansible-lint issues
 
 ## 9.0.0+1.12.5

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-cilium_chart_version: "1.12.5"
+cilium_chart_version: "1.13.0"
 
 # Helm chart name
 cilium_chart_name: "cilium"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Helm chart version (uses Cilium v1.12.5)
-cilium_chart_version: "1.12.5"
+# Helm chart version (uses Cilium v1.13.0)
+cilium_chart_version: "1.13.0"
 
 # Helm release name
 cilium_release_name: "cilium"

--- a/tasks/pre_flight_check.yml
+++ b/tasks/pre_flight_check.yml
@@ -24,7 +24,7 @@
 
     - name: Register current Cilium pre flight pods running
       ansible.builtin.set_fact:
-        cilium_pre_flight_pods_running: "{{ cilium_pre_flight_check_daemonset | json_query(query) }}"
+        cilium_pre_flight_pods_running: "{{ cilium_pre_flight_check_daemonset | to_json | from_json | community.general.json_query(query) }}"
       vars:
         query: "resources[0].status.numberReady"
       run_once: true

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -186,6 +186,7 @@
         chart_ref: "{{ cilium_chart_name }}"
         chart_version: "{{ cilium_chart_version }}"
         release_namespace: "{{ cilium_namespace }}"
+        force: true
         create_namespace: false
         update_repo_cache: true
         values_files:

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -23,7 +23,7 @@
 
 - name: Register current Cilium pods running
   ansible.builtin.set_fact:
-    cilium_pods_running: "{{ cilium__daemonset | json_query(query) }}"
+    cilium_pods_running: "{{ cilium__daemonset | to_json | from_json | community.general.json_query(query) }}"
   vars:
     query: "resources[0].status.numberReady"
   run_once: true
@@ -41,7 +41,7 @@
 
 - name: Register if there is a Cilium pre-flight check deployment leftover
   ansible.builtin.set_fact:
-    cilium_pre_flight_check_leftover: "{{ cilium__pre_flight_check_deployment | json_query(query) }}"
+    cilium_pre_flight_check_leftover: "{{ cilium__pre_flight_check_deployment | to_json | from_json | community.general.json_query(query) }}"
   vars:
     query: "resources[0].metadata.name"
   run_once: true
@@ -113,7 +113,7 @@
 
 - name: Register Cilium pre flight ready replicas
   ansible.builtin.set_fact:
-    cilium_pre_flight_ready_replicas: "{{ cilium__pre_flight_deployment | json_query(query) }}"
+    cilium_pre_flight_ready_replicas: "{{ cilium__pre_flight_deployment | to_json | from_json | community.general.json_query(query) }}"
   vars:
     query: "resources[0].status.readyReplicas"
   run_once: true
@@ -121,7 +121,7 @@
 
 - name: Register Cilium pre flight replicas
   ansible.builtin.set_fact:
-    cilium_pre_flight_replicas: "{{ cilium__pre_flight_deployment | json_query(query) }}"
+    cilium_pre_flight_replicas: "{{ cilium__pre_flight_deployment | to_json | from_json | community.general.json_query(query) }}"
   vars:
     query: "resources[0].status.replicas"
   run_once: true


### PR DESCRIPTION
- upgrade to Cilium `v1.13.0`. Please check [](https://docs.cilium.io/en/v1.13/operations/upgrade/#current-release-required-changes) for possible incompatible changes and deprecations.
- added `force:true` in case of Helm chart upgrade to make sure the upgrade happens no matter what
- `tasks/pre_flight_check.yml` + `upgrade.yml`: fix ansible-lint issues