### PR TITLE
13.1.0+1.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
+## 13.1.0+1.15.8
+
+### Update
+
+- upgrade to Cilium `v1.15.8`
+
+### Molecule
+
+- replace Vagrant `alvistack/ubuntu-22.04` boxes with `alvistack/ubuntu-24.04`
+
 ## 13.0.0+1.15.3
 
 ### Breaking
 
 - changes in `templates/cilium_values_default.yml.j2`:
-  - added `kubeProxyReplacement`, `nodePort` and `socketLB` (this is needed because BPF masquerade requires NodePort)
+- added `kubeProxyReplacement`, `nodePort` and `socketLB` (this is needed because BPF masquerade requires NodePort)
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 
 **Recent changes:**
 
+## 13.1.0+1.15.8
+
+### Update
+
+- upgrade to Cilium `v1.15.8
+
+### Molecule
+
+- replace Vagrant `alvistack/ubuntu-22.04` boxes with `alvistack/ubuntu-24.04`
+
 ## 13.0.0+1.15.3
 
 ### Breaking
@@ -71,7 +81,7 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 
 ```yaml
 # Helm chart version
-cilium_chart_version: "1.15.3"
+cilium_chart_version: "1.15.8"
 
 # Helm chart name
 cilium_chart_name: "cilium"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Helm chart version (uses Cilium v1.15.3)
-cilium_chart_version: "1.15.3"
+# Helm chart version (uses Cilium v1.15.8)
+cilium_chart_version: "1.15.8"
 
 # Helm release name
 cilium_release_name: "cilium"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -26,7 +26,7 @@ platforms:
         type: static
         ip: 172.16.10.5
   - name: test-controller1
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -41,7 +41,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-controller2
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -56,7 +56,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-controller3
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -70,7 +70,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-etcd1
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -82,7 +82,7 @@ platforms:
         type: static
         ip: 172.16.10.100
   - name: test-etcd2
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -94,7 +94,7 @@ platforms:
         type: static
         ip: 172.16.10.110
   - name: test-etcd3
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -106,7 +106,7 @@ platforms:
         type: static
         ip: 172.16.10.120
   - name: test-worker1
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -120,7 +120,7 @@ platforms:
         type: static
         ip: 172.16.10.200
   - name: test-worker2
-    box: alvistack/ubuntu-22.04
+    box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -12,6 +12,8 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
+    - name: Reboot for kernel updates
+      ansible.builtin.reboot:
 
 - name: Harden hosts
   hosts: all
@@ -82,11 +84,10 @@
       vars:
         packages:
           - conntrack
-          - python3-pip
 
     - name: Install kubernetes Python package
-      ansible.builtin.pip:
-        name: kubernetes
+      ansible.builtin.package:
+        name: python3-kubernetes
         state: present
 
     - name: Install Helm role


### PR DESCRIPTION
### Update

- upgrade to Cilium `v1.15.8`

### Molecule

- replace Vagrant `alvistack/ubuntu-22.04` boxes with `alvistack/ubuntu-24.04`